### PR TITLE
Fix "import" directive for less, sass, scss, stylus modules

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,6 @@
+## 1.1.2
+Fix "import" directive for less, sass, scss, stylus modules
+
 ## 1.0.2
 Fix detect Windows filename path
 

--- a/__tests__/source/config/vars.less
+++ b/__tests__/source/config/vars.less
@@ -1,0 +1,3 @@
+@red: #f00;
+@yellow: #ffd630;
+@gray: #cdd;

--- a/__tests__/source/config/vars.sass
+++ b/__tests__/source/config/vars.sass
@@ -1,0 +1,3 @@
+$red: #f00;
+$yellow: #ffd630;
+$gray: #cdd;

--- a/__tests__/source/config/vars.scss
+++ b/__tests__/source/config/vars.scss
@@ -1,0 +1,3 @@
+$red: #f00;
+$yellow: #ffd630;
+$gray: #cdd;

--- a/__tests__/source/config/vars.styl
+++ b/__tests__/source/config/vars.styl
@@ -1,0 +1,3 @@
+customRed = #f00
+customYellow = #ffd630
+customGray = #cdd

--- a/__tests__/source/style.less
+++ b/__tests__/source/style.less
@@ -1,3 +1,5 @@
+@import "./config/vars.less";
+
 /**
 .super_hidden_class {
     display: block;
@@ -8,25 +10,25 @@
     0% {
         bottom: 0;
         left: 340px;
-        background: #f00;
+        background: @red;
     }
 
     33% {
         bottom: 340px;
         left: 340px;
-        background: #ffd630;
+        background: @yellow;
     }
 
     66% {
         bottom: 340px;/** .hiddenclass15:before{content:".hiddenclass20{display: block}"} /** {}dd*/
         left: 40px;
-        background: #ffd630;
+        background: @yellow;
     }
 
     100% {
         bottom: 0;
         left: 40px;
-        background: #f00;
+        background: @red;
     }
 
 }
@@ -34,7 +36,7 @@
 .class1 {
     display: block;
     content: ".hiddenclass{display: block;}";
-    color: #cdd;
+    color: @gray;
 
     & label {
         display: block;

--- a/__tests__/source/style.sass
+++ b/__tests__/source/style.sass
@@ -1,3 +1,5 @@
+@import "config/vars.sass"
+
 /**
  *.super_hidden_class {
  *    display: block;
@@ -7,29 +9,29 @@
   0%
     bottom: 0
     left: 340px
-    background: #f00
+    background: $red
 
   33%
     bottom: 340px
     left: 340px
-    background: #ffd630
+    background: $yellow
 
   66%
     bottom: 340px
     /** .hiddenclass15:before{content:".hiddenclass20{display: block}"} /** {}dd
     left: 40px
-    background: #ffd630
+    background: $yellow
 
   100%
     bottom: 0
     left: 40px
-    background: #f00
+    background: $red
 
 
 .class1
   display: block
   content: ".hiddenclass{display: block;}"
-  color: #cdd
+  color: $gray
 
 .class2, .class3
   display: block

--- a/__tests__/source/style.scss
+++ b/__tests__/source/style.scss
@@ -1,3 +1,5 @@
+@import "./config/vars.scss";
+
 /**
 .super_hidden_class {
     display: block;
@@ -8,25 +10,25 @@
     0% {
         bottom: 0;
         left: 340px;
-        background: #f00;
+        background: $red;
     }
 
     33% {
         bottom: 340px;
         left: 340px;
-        background: #ffd630;
+        background: $yellow;
     }
 
     66% {
         bottom: 340px;/** .hiddenclass15:before{content:".hiddenclass20{display: block}"} /** {}dd*/
         left: 40px;
-        background: #ffd630;
+        background: $yellow;
     }
 
     100% {
         bottom: 0;
         left: 40px;
-        background: #f00;
+        background: $red;
     }
 
 }
@@ -34,7 +36,7 @@
 .class1 {
     display: block;
     content: ".hiddenclass{display: block;}";
-    color: #cdd;
+    color: $gray;
 
     & label {
         display: block;

--- a/__tests__/source/style.styl
+++ b/__tests__/source/style.styl
@@ -1,3 +1,5 @@
+@import "./config/vars.styl"
+
 /**
 .super_hidden_class
     display: block
@@ -7,27 +9,27 @@
     0%
         bottom: 0
         left: 340px
-        background: #f00
+        background: customRed
 
     33%
         bottom: 340px
         left: 340px
-        background: #ffd630
+        background: customYellow
 
     66%
         bottom: 340px/** .hiddenclass15:before{content:".hiddenclass20{display: block}"} /** {}dd*/
         left: 40px
-        background: #ffd630
+        background: customYellow
 
     100%
         bottom: 0
         left: 40px
-        background: #f00
+        background: customRed
 
 .class1
     display: block
     content: ".hiddenclass{display: block}"
-    color: #cdd
+    color: customGray
 
 .class2, .class3
     display: block

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-css-modules-transform",
   "description": "Jest's preprocessor for css, sass, less, stylus modules generated with Webpack",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "license": "MIT",
   "author": "Mikhail Bodrov",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ module.exports = {
         switch (extention) {
             case 'styl':
                 stylus = stylus || require('stylus');
-                stylus.render(src, {filename}, (err, css) => {
+                stylus.render(src, {filename: path}, (err, css) => {
                     if (err) {
                         throw err;
                     }
@@ -125,12 +125,12 @@ module.exports = {
 
             case 'sass': case 'scss':
                 sass = sass || require('node-sass');
-                textCSS = String(sass.renderSync({data: src, file: filename, indentedSyntax: extention === 'sass'}).css);
+                textCSS = String(sass.renderSync({data: src, file: path, indentedSyntax: extention === 'sass'}).css);
                 break;
 
             case 'less':
                 less = less || require('less');
-                less.render(src, {filename}, (err, css) => {
+                less.render(src, {filename: path}, (err, css) => {
                     if (err) {
                         throw err;
                     }


### PR DESCRIPTION
Preprocessors like node-sass can't find nested imported files into modules. Because "includePath" refers to the directory where the command "jest" was executed.