### PR TITLE
infinite loop when css comment contains apostrophe

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,8 @@ const getCSSSelectors = (css, path) => {
             throw Error(`Parse error ${path}`);
         }
 
-        if (css.indexOf('/**', i) === i) {
-            i = css.indexOf('*/', i + 3);
+        if (css.indexOf('/*', i) === i) {
+            i = css.indexOf('*/', i + 2);
             continue;
         }
 


### PR DESCRIPTION
The following css resulted in an infinte loop:

.x {
  /* ' */
}