### PR TITLE
Soft-code moduleTemplate via jest-css-modules-transform-config.js

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,7 @@ It supports `pure CSS`, `SCSS`, `SASS`, `STYLUS` and `LESS`.
 
 ### Options
 You can save preproccessor options in file `jest-css-modules-transform-config.js` in root of your project(Where is the file `package.json`).
-You can pass options for your preprocessors.
+You can pass options for your preprocessors or override the default `moduleTemplate`.
 ##### example:  
 ```js
 const path = require('path');  
@@ -49,6 +49,7 @@ module.exports = {
     stylusConfig: {
         paths: [additionalResolvePath],
     },
+    moduleTemplate = 'module.exports = %s'
 };
 ```
 For all preprocessor options see offical documentations for Sass, Less, Stylus.

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ const getCSSSelectors = (css, path) => {
 };
 
 const getPreProcessorsConfig = (function wrap() {
-    const preProcessorsConfigDefalut = {
+    const preProcessorsConfigDefault = {
         sassConfig: {},
         lessConfig: {},
         stylusConfig: {},
@@ -127,7 +127,7 @@ const getPreProcessorsConfig = (function wrap() {
         try {
             preProcessorsConfig = require(resolve(rootDir, 'jest-css-modules-transform-config.js'));
         } catch (e) {
-            preProcessorsConfig = preProcessorsConfigDefalut;
+            preProcessorsConfig = preProcessorsConfigDefault;
         }
 
         return preProcessorsConfig;
@@ -195,6 +195,7 @@ module.exports = {
                 break;
         }
 
-        return moduleTemplate.replace('%s', JSON.stringify(getCSSSelectors(textCSS, path)));
+        return (preProcessorsConfig.moduleTemplate || moduleTemplate)
+            .replace('%s', JSON.stringify(getCSSSelectors(textCSS, path)));
     },
 };


### PR DESCRIPTION
The module template is currently hard-coded to `exports.default = %s`. 
Some webpack configurations require`module.exports = %s` instead. 

This change allows the default to be overridden by adding 
it to `jest-css-modules-transform-config.js`.