### PR TITLE
Changing export to proxy object

### DIFF
--- a/__tests__/config-sass.spec.js
+++ b/__tests__/config-sass.spec.js
@@ -17,6 +17,6 @@ describe('config sassrc', () => {
 
     it('should import .sass with .sassrc', () => {
         const sassFile = require('./source/style-with-sassrc.sass').default;
-        expect(sassFile).toEqual({class: 'class', bar: 'bar'});
+        expect({...sassFile}).toEqual({class: 'class', bar: 'bar'});
     });
 });

--- a/__tests__/config.spec.js
+++ b/__tests__/config.spec.js
@@ -18,21 +18,21 @@ describe('config', () => {
 
     it('should import .sass', () => {
         const sassFile = require('./source/style-with-config.sass').default;
-        expect(sassFile).toEqual(cssFileExpect);
+        expect({...sassFile}).toEqual(cssFileExpect);
     });
 
     it('should import .scss', () => {
         const scssFile = require('./source/style-with-config.scss').default;
-        expect(scssFile).toEqual(cssFileExpect);
+        expect({...scssFile}).toEqual(cssFileExpect);
     });
 
     it('should import .less', () => {
         const lessFile = require('./source/style-with-config.less').default;
-        expect(lessFile).toEqual(cssFileExpect);
+        expect({...lessFile}).toEqual(cssFileExpect);
     });
 
     it('should import .styl', () => {
         const stulysFile = require('./source/style-with-config.styl').default;
-        expect(stulysFile).toEqual(cssFileExpect);
+        expect({...stulysFile}).toEqual(cssFileExpect);
     });
 });

--- a/__tests__/main.spec.js
+++ b/__tests__/main.spec.js
@@ -15,7 +15,7 @@ describe('jest-css-modules', () => {
         ['less', lessFile],
     ].forEach(([ext, style]) => {
         it(`should import .${ext}`, () => {
-            expect(style).toEqual(cssFileExpect);
+            expect({...style}).toEqual(cssFileExpect);
         });
 
         it(`should import .${ext} and keyframes should be last`, () => {
@@ -28,7 +28,7 @@ describe('jest-css-modules', () => {
     });
 
     it('should import .css with nested', () => {
-        expect(cssNestedFile).toEqual({
+        expect({...cssNestedFile}).toEqual({
             foo: 'foo',
             foo__bar: 'foo__bar',
             foo__zoo: 'foo__zoo',

--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,24 @@ let stylus;
 let sass;
 let less;
 
-const moduleTemplate = `
+const moduleTemplate = ({selectors, path}) => `
     "use strict";
 
     Object.defineProperty(exports, "__esModule", {
-       value: true
+        value: true
     });
 
-    exports.default = %s;
+    const data = new Proxy(${selectors}, {
+        get: function(obj, prop) {
+            if (prop in obj) {
+                return obj[prop];
+            } else {
+                throw new Error(\`${path} has no exported member \${String(prop)}\`);
+            }
+        }
+    })
+
+    exports.default = data;
 `;
 
 const REG_EXP_NAME_BREAK_CHAR = /[\s,.{/#[:]/;
@@ -219,6 +229,9 @@ module.exports = {
                 break;
         }
 
-        return moduleTemplate.replace('%s', JSON.stringify(getCSSSelectors(textCSS, path)));
+        return moduleTemplate({
+            selectors: JSON.stringify(getCSSSelectors(textCSS, path)),
+            path,
+        });
     },
 };


### PR DESCRIPTION
### Description 
This PR will help find incorrect imports from css-modules.  If you had a typo in an import, you get a classname of `undefined`.  I've seen this get committed multiple times, as you have to spot this manually.  

By using a Proxy object we could catch this, and throw an error for importing incorrect selectors.

### Issue
This breaks the `.toEqual` matcher in **all** jest tests, as [it tries to access `.asymmetricMatch` property in the objects](https://github.com/facebook/jest/blob/master/packages/expect/src/jasmineUtils.ts#L40-L42).  I've done a shallow clone of the Proxy object to get around this, but it's not ideal.

I'd love to know your thoughts on this
